### PR TITLE
Make CDN links easier to copy and paste

### DIFF
--- a/_installation.en.md.erb
+++ b/_installation.en.md.erb
@@ -36,10 +36,10 @@ CDN
 
 If you'd prefer to use the [jsDelivr](http://www.jsdelivr.com/#!interact.js) or
 [cdnjs](https://cdnjs.com/libraries/interact.js) CDNs instead, simply add a
-script tag pointing to either
+script tag pointing to one of:
 
-- `//cdn.jsdelivr.net/interact.js/<%= data.site.current_version %>/interact.min.js` or
-- `//cdnjs.cloudflare.com/ajax/libs/interact.js/<%= data.site.current_version %>/interact.min.js`.
+- `//cdn.jsdelivr.net/interact.js/<%= data.site.current_version %>/interact.min.js`
+- `//cdnjs.cloudflare.com/ajax/libs/interact.js/<%= data.site.current_version %>/interact.min.js`
 
 Module
 ------


### PR DESCRIPTION
Removing trailing text means that triple-click selects the URL only.

I tripped up a couple of times by triple-clicking then copying, not realising I had copied the trailing dot. Took a while to figure out why the script wasn't loading 😄 